### PR TITLE
Run autoscale automatically after type chage

### DIFF
--- a/src/pyeyes/viewers.py
+++ b/src/pyeyes/viewers.py
@@ -131,7 +131,12 @@ class ComparativeViewer(Viewer, param.Parameterized):
 
         # Instantiate slicer
         self.slicer = NDSlicer(
-            self.dataset, self.vdims, cdim="ImgName", clabs=img_names, cat_dims=cat_dims
+            self.dataset,
+            self.vdims,
+            cdim="ImgName",
+            clabs=img_names,
+            cat_dims=cat_dims,
+            viewer=self,
         )
 
         """
@@ -329,7 +334,7 @@ class ComparativeViewer(Viewer, param.Parameterized):
 
         self.app[0][1][2].value = self.slicer.cmap
 
-    def _autoscale_clim(self, event):
+    def _autoscale_clim(self, event=None):
         """
         Routine to run to update the viewing dimensions of the data.
         """


### PR DESCRIPTION
It's a very ugly solution; let's not merge for now and think of a better way; this is just a first try.

The goal:
Whenever someone switches from T1 to T2 (for example), it would be nice to run the autoscale function since the scale of values is completely different. However, it seems that just running the slicer's autoscale function doesn't change the scale in the contrast tab (but it does apply the autoscale and uses the correct clim after autoscaling). 
The solution here passes the viewer object that contains the slicer to the slicer, which feels unsafe...