### PR TITLE
Push dev versions to pypi

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,0 +1,38 @@
+name: Publish Dev Version to PyPI
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build-and-publish-dev:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10.12'
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine setuptools_scm
+
+      - name: Build Package
+        run: python -m build
+
+      # Step 7: Publish the Dev Version to PyPI
+      - name: Publish Dev Version to PyPI
+        # Here, we're publishing to PyPI. We might want to switch to Test PyPI. 
+        # ('--repository-url https://test.pypi.org/legacy/' to publish to Test PyPI)
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_KEY }}
+        run: twine upload --skip-existing dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,5 +54,5 @@ package-dir = {"" = "src"}
 pyeyes = ["cmap/*.csv"]
 
 [tool.setuptools_scm]
-version_scheme = "post-release"
+version_scheme = "guess-next-dev"
 local_scheme = "node-and-date"


### PR DESCRIPTION
Added a workflow to push dev versions to pypi.
Users running `pip install --upgrade pyeyes` will not get the dev versions by default, and will only get stable releases.
However, they can update to dev by running `pip install --upgrade --pre pyeyes`