### PR TITLE
Fix Dev Workflow: Remove Local Version Segment for PyPI Compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,4 +55,4 @@ pyeyes = ["cmap/*.csv"]
 
 [tool.setuptools_scm]
 version_scheme = "guess-next-dev"
-local_scheme = "node-and-date"
+local_scheme = "no-local-version"


### PR DESCRIPTION
This PR fixes the error encountered in the dev workflow where package versions with local segments (e.g. 0.1.dev89+gb126694) were rejected by PyPI. By updating pyproject.toml to use "no-local-version" as the local scheme, dev builds now produce compliant version numbers (e.g. 0.1.dev89) that can be uploaded to PyPI without issue.