### PR TITLE
Export sliceable html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 play/
 tests/profs/
+tests/exports/
 
 # deploy
 dist/

--- a/src/pyeyes/app.py
+++ b/src/pyeyes/app.py
@@ -6,7 +6,7 @@ from .viewers import Viewer
 
 
 def launch_viewers(
-    viewer_dict: Union[Viewer, Dict[str, Viewer]], port: Optional[int] = None, **kwargs
+    viewer_dict: Union[Viewer, Dict[str, Viewer]], port: Optional[int] = 0, **kwargs
 ):
     """
     Launches a web page hosting viewer(s).

--- a/src/pyeyes/slicers.py
+++ b/src/pyeyes/slicers.py
@@ -886,7 +886,7 @@ class NDSlicer(param.Parameterized):
         row = row.cols(Ncols)
 
         # Set attributes
-        self.Figure = pn.Row(row)
+        self.Figure = row
 
     def update_figure(self, input_data: Dict[str, dict]):
         """


### PR DESCRIPTION
This pull request adds Static HTML export functionality.

Enhancements to the `viewers` module:

* Added new parameters `html_export_path` and `html_export_page_name` to `ComparativeViewer` class for specifying HTML export paths and page names.
* Implemented the `_export_html` method to enable exporting the viewer as an interactive HTML file, including handling of range selections for dimensions and saving the HTML with appropriate configurations.
* Updated `_build_export_widgets` method to include widgets for configuring HTML export paths, page names, and dimension ranges for data exports.

Updates to launch parameters:

* Changed the default value of the `port` parameter in `launch_viewers` function from `None` to `0` to ensure a port is always specified.

Improvements to figure update process:

* Modified `_diff_callback` method to directly assign the row to `self.Figure` instead of wrapping it in a `pn.Row`.