### PR TITLE
Figures title in the center

### DIFF
--- a/src/pyeyes/slicers.py
+++ b/src/pyeyes/slicers.py
@@ -51,6 +51,8 @@ def _format_image(plot, element):
     plot.state.outline_line_alpha = 1.0
     plot.state.title.text_color = themes.VIEW_THEME.text_color
     plot.state.title.text_font = themes.VIEW_THEME.text_font
+    # Center title above image
+    plot.state.title.align = "center"
 
 
 def _hide_image(plot, element):


### PR DESCRIPTION
Any reason not to do that?
before:
![image](https://github.com/user-attachments/assets/57e7c4af-5e20-4280-bcc6-6116f8e94443)

after:
![image](https://github.com/user-attachments/assets/00d766de-8c0a-4f1c-ac24-952d678a33ed)
